### PR TITLE
feat: Add Dockerfile for multi-stage build of Spring Boot server

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,50 @@
+# Multi-stage build for Spring Boot server
+FROM maven:3.9.6-eclipse-temurin-21 AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy pom.xml and download dependencies
+COPY pom.xml .
+RUN mvn dependency:go-offline -B
+
+# Copy source code
+COPY src ./src
+
+# Build the application
+RUN mvn clean package -DskipTests
+
+# Production stage
+FROM eclipse-temurin:21-jre
+
+# Install curl for health checks
+# RUN apk add --no-cache curl
+# Install curl for health checks (Debian-based)
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+# RUN addgroup -S spring && adduser -S spring -G spring
+RUN groupadd --system spring && useradd --system --gid spring spring
+
+# Set working directory
+WORKDIR /app
+
+# Copy the built jar from the build stage
+# COPY --from=build /app/target/*.jar app.jar
+COPY --from=builder /app/target/*.jar app.jar
+
+# Change ownership to spring user
+RUN chown spring:spring app.jar
+
+# Switch to non-root user
+USER spring
+
+# Expose port 8080
+EXPOSE 8080
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8080/actuator/health || exit 1
+
+# Start the application
+ENTRYPOINT ["java", "-jar", "app.jar"]


### PR DESCRIPTION
This pull request introduces a new multi-stage `Dockerfile` for building and running the Spring Boot server. The Dockerfile is designed to efficiently build the application using Maven, set up a secure runtime environment, and provide a health check endpoint.

Key changes in the new Dockerfile:

**Build and Packaging Improvements:**

* Implements a multi-stage build using a Maven image (`maven:3.9.6-eclipse-temurin-21`) to compile and package the Spring Boot application, ensuring only the final executable JAR is included in the runtime image.

**Runtime Environment and Security:**

* Uses a minimal JRE base image (`eclipse-temurin:21-jre`) for the production stage and creates a non-root `spring` user to run the application, enhancing container security.
* Installs `curl` for health checks and sets up the working directory and proper file ownership for the application JAR.

**Operational Enhancements:**

* Adds a `HEALTHCHECK` instruction to monitor the application's health via the `/actuator/health` endpoint, improving deployability and reliability in container orchestration environments.
* Exposes port 8080 and sets the entrypoint to run the Spring Boot application.